### PR TITLE
Update faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,19 +1,25 @@
 # FAQs
 
+## Why XAML?
+Designers and Developers occupy a variety of different toolsets to create their intended experiences for users with a variety of dynamic variables in mind; such as screen sizes, touch dimensions, 2D and 3D entities, animation(s) etc. XAML is about bridging the gap between these two worlds by ensuring both platforms and tooling can agree on a standard based vocabulary. The intent and philosophy of XAML is to remove areas where compromise is enforced due to platform limitations and/or tooling export functionality.
+
 ## What is XAML Standard?
 XAML Standard is a vocabulary specification that defines a standard XAML markup vocabulary. Frameworks that support XAML Standard can share common XAML based UI definitions. 
 
-The goal is for the first version, XAML Standard 1.0, to be available later this year. Post specification plans include support of XAML standard in Xamarin.Forms and UWP.
+The goal is for the first version, XAML Standard 1.0, to be available later this year. Post specification plans include support of XAML standard.
 
 ## What is the relationship between XAML Standard, UWP, Xamarin.Forms?
 * XAML Standard is the specification document that defines which APIs and schema concepts a XAML based framework needs to implement.
 * UWP and Xamarin Forms are concrete frameworks that implement the XAML Standard. 
 
 ## What can I do with XAML Standard that I couldn’t do before?
-We are at the beginning of a journey that makes it easy for you to reuse your XAML source files between Xamarin.Forms, UWP and even WPF to a large extent. For example - once XAML Standard is supported by Xamarin.Forms, you can use `<TextBlock/>` in your markup and have it supported in a Xamarin.Forms app targeting iOS and Android instead of needing to know and use `<Label/>` like you did before.
+We are at the beginning of a journey that makes it easy for you to reuse your XAML source files between platforms and tooling. The focus is primarily on bringing the old up to an agreed standard whilst focusing on the new to adhere to a new standard. For example - inside XAML standard focus on `<TextBlock/>` that would later translate into platform implementations (`<Label/>`) is abstracted from the original author(s).
 
 ## What should I do if I develop UWPs or Xamarin.Forms apps today?
-Nothing changes for existing developers - you can continue to use the same APIs you have always used in both frameworks. XAML Standard will help you reuse/share any common UI code that you wish to share between frameworks.
+Nothing changes for existing developers - you can continue to use the same APIs you have always used in both frameworks. XAML Standard will help you reuse/share any common UI code that you wish to share between frameworks. 
+
+## What should I do if I develop WPF and/or Silverlight still today?
+Monitor the proposed standard carefully, look at ways in which the standard could be retrofitted via component/control development to help move you closer to adhering to its likely implementation. Retroactively upgrading WPF to fit the proposed standard is unlikely, however once the standard retains a calm state it will enable you a more structured roadmap on what to do next with existing applications designed in the WPF/Silverlight platforms.
 
 ## How can I participate?
 We are in the early stages of defining the spec right now, you can see a draft of XAML Standard 1.0 getting defined [here](https://github.com/Microsoft/xaml-standard/blob/staging/docs/v1draft.md). We encourage you to start a discussion or give us direct feedback by [filing an issue](https://github.com/Microsoft/xaml-standard/issues) or [starting a proposal](https://github.com/Microsoft/xaml-standard/labels/proposal) for what you would like to see in v1 and beyond.


### PR DESCRIPTION
- The why is important.

- What isn't tightly coupled to UWP/Xamarin they are coupled to it. To ensure there is a clearly defined line of separation here or its moot to have a standard.

- Mixing the pitch that UWP/Xamarin are part of XAML is muddying the waters as you also have a legion of WPF/Silverlight minds looking at this to be a way out of the legacy. Until UWP/Xamarin agree on a "merger" the entire repo should defocus on what they do right/wrong today but focus more on what they *should* be doing tomorrow. This will enable also potential around moving existing legacy Silverlight/WPF into a more modern world without the glitches  of UWP/Xamarin implementations.

- WPF/Silverlight solutions still exist today. Microsoft may not want that reality to exist but in the spirit of OSS its not about Microsoft wants, its about "our" wants.